### PR TITLE
add selectable text and trim

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -211,8 +211,8 @@ class _MyHomePageState extends State<MyHomePage> {
       tagMap[tag] = true;
     }
     var jsonMap = {
-      'name': nameController.text,
-      'description': descriptionController.text,
+      'name': nameController.text.trim(),
+      'description': descriptionController.text.trim(),
       'createdDate': Timestamp.now(),
       'tags': tagMap
     };

--- a/lib/spell_page.dart
+++ b/lib/spell_page.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'spell.dart';
 
@@ -33,7 +34,7 @@ class _SpellPageState extends State<SpellPage> {
         child: Column(
           children: <Widget>[
             const SizedBox(height: 40.0),
-            Text(
+            SelectableText(
               widget.spell.name,
               style: TextStyle(
                   fontSize: 28.0,
@@ -46,7 +47,7 @@ class _SpellPageState extends State<SpellPage> {
                 widget.spell.tags.length,
                 (int index) => Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 10.0),
-                  child: Text(
+                  child: SelectableText(
                     widget.spell.tags[index],
                     style: TextStyle(
                       fontSize: 20.0,
@@ -67,7 +68,7 @@ class _SpellPageState extends State<SpellPage> {
             const SizedBox(height: 20.0),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 40.0),
-              child: Text(
+              child: SelectableText(
                 widget.spell.description,
                 style: const TextStyle(fontSize: 20.0),
               ),


### PR DESCRIPTION
Makes the text on the spell page selectable for copy/paste purposes
Also adds .trim() to the inputs on spell submission to take off extra whitespace characters of name and descriptions fields