### PR TITLE
open spell page on submit

### DIFF
--- a/lib/database_service.dart
+++ b/lib/database_service.dart
@@ -17,17 +17,23 @@ class DatabaseService {
     return query.snapshots();
   }
 
-  void addSpell(Map<String, dynamic> spell) {
-    _firestoreInstance.collection(spellsCollectionReference).add(spell);
+  Future<String> addSpell(Spell spell) async {
+    var docRef = await _firestoreInstance
+        .collection(spellsCollectionReference)
+        .add(spell.toJson());
+    return docRef.id;
   }
 
-  Spell? getSpellById(String id) {
-    _firestoreInstance.doc(id).get().then((DocumentSnapshot doc) {
-      final data = doc.data() as Map<String, dynamic>;
-      return Spell.fromJson(data);
-    }, onError: (e) {
-      debugPrint("Error getting document: $e");
-    });
+  Future<Spell?> getSpellById(String id) async {
+    try {
+      var spellDoc = await _firestoreInstance
+          .collection(spellsCollectionReference)
+          .doc(id)
+          .get();
+      return Spell.fromJson(spellDoc.data()!);
+    } on Exception catch (e) {
+      debugPrint('Failed to retrive spell with message \'$e.\'');
+    }
     return null;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:a_billion_spells/database_service.dart';
+import 'package:a_billion_spells/spell.dart';
+import 'package:a_billion_spells/spell_page.dart';
 import 'package:a_billion_spells/spell_search_page.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
@@ -184,13 +186,16 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
                 const SizedBox(height: 30.0),
                 ElevatedButton(
-                  onPressed: () {
+                  onPressed: () async {
                     if (formKey.currentState!.validate()) {
-                      DatabaseService().addSpell(generateSpellJSON());
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(
-                              'Submitting your spell ${nameController.text}!'),
+                      var spellId =
+                          await DatabaseService().addSpell(generateSpell());
+                      // ignore: use_build_context_synchronously
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) => SpellPage(
+                            spellId: spellId,
+                          ),
                         ),
                       );
                     }
@@ -205,7 +210,7 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  Map<String, dynamic> generateSpellJSON() {
+  Spell generateSpell() {
     Map<String, bool> tagMap = {};
     for (var tag in tags) {
       tagMap[tag] = true;
@@ -216,6 +221,6 @@ class _MyHomePageState extends State<MyHomePage> {
       'createdDate': Timestamp.now(),
       'tags': tagMap
     };
-    return jsonMap;
+    return Spell.fromJson(jsonMap);
   }
 }

--- a/lib/spell.dart
+++ b/lib/spell.dart
@@ -24,11 +24,15 @@ class Spell {
   }
 
   Map<String, dynamic> toJson() {
+    var tagMap = {};
+    for (var tag in tags) {
+      tagMap[tag] = true;
+    }
     return {
       "name": name,
       "description": description,
       "createdDate": createdDate,
-      "tags": tags
+      "tags": tagMap
     };
   }
 }

--- a/lib/spell_page.dart
+++ b/lib/spell_page.dart
@@ -1,13 +1,12 @@
 import 'dart:math' as math;
+import 'package:a_billion_spells/database_service.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'spell.dart';
 
 class SpellPage extends StatefulWidget {
-  const SpellPage({super.key, required this.spell, required this.spellId});
+  const SpellPage({super.key, required this.spellId});
 
-  final Spell spell;
   final String spellId;
 
   @override
@@ -17,65 +16,87 @@ class SpellPage extends StatefulWidget {
 class _SpellPageState extends State<SpellPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).canvasColor,
-        foregroundColor: Colors.black,
-        elevation: 0,
-        title: Text(
-          "A Billion Spells: The Vault",
-          style: TextStyle(
-            fontSize: 30.0,
-            fontFamily: GoogleFonts.eduVicWaNtBeginner().fontFamily,
-          ),
-        ),
-      ),
-      body: SingleChildScrollView(
-        child: Column(
-          children: <Widget>[
-            const SizedBox(height: 40.0),
-            SelectableText(
-              widget.spell.name,
-              style: TextStyle(
-                  fontSize: 28.0,
-                  fontFamily: GoogleFonts.eduVicWaNtBeginner().fontFamily),
-            ),
-            const SizedBox(height: 12.0),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: List<Widget>.generate(
-                widget.spell.tags.length,
-                (int index) => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 10.0),
-                  child: SelectableText(
-                    widget.spell.tags[index],
-                    style: TextStyle(
-                      fontSize: 20.0,
-                      fontFamily: GoogleFonts.abel().fontFamily,
-                      shadows: <Shadow>[
-                        Shadow(
-                          blurRadius: 6,
-                          color: Color(
-                            (math.Random().nextDouble() * 0xFFFFFF).toInt(),
-                          ).withOpacity(1.0),
-                        ),
-                      ],
-                    ),
-                  ),
+    return FutureBuilder<Spell?>(
+      future: DatabaseService().getSpellById(widget.spellId),
+      builder: (BuildContext context, AsyncSnapshot<Spell?> snapshot) {
+        if (snapshot.hasData) {
+          Spell? spell = snapshot.data;
+          return Scaffold(
+            appBar: AppBar(
+              backgroundColor: Theme.of(context).canvasColor,
+              foregroundColor: Colors.black,
+              elevation: 0,
+              title: Text(
+                "A Billion Spells: The Vault",
+                style: TextStyle(
+                  fontSize: 30.0,
+                  fontFamily: GoogleFonts.eduVicWaNtBeginner().fontFamily,
                 ),
               ),
             ),
-            const SizedBox(height: 20.0),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 40.0),
-              child: SelectableText(
-                widget.spell.description,
-                style: const TextStyle(fontSize: 20.0),
+            body: SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
+                  const SizedBox(height: 40.0),
+                  SelectableText(
+                    spell!.name,
+                    style: TextStyle(
+                        fontSize: 28.0,
+                        fontFamily:
+                            GoogleFonts.eduVicWaNtBeginner().fontFamily),
+                  ),
+                  const SizedBox(height: 12.0),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: List<Widget>.generate(
+                      spell.tags.length,
+                      (int index) => Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10.0),
+                        child: SelectableText(
+                          spell.tags[index],
+                          style: TextStyle(
+                            fontSize: 20.0,
+                            fontFamily: GoogleFonts.abel().fontFamily,
+                            shadows: <Shadow>[
+                              Shadow(
+                                blurRadius: 6,
+                                color: Color(
+                                  (math.Random().nextDouble() * 0xFFFFFF)
+                                      .toInt(),
+                                ).withOpacity(1.0),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20.0),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 40.0),
+                    child: SelectableText(
+                      spell.description,
+                      style: const TextStyle(fontSize: 20.0),
+                    ),
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
-      ),
+          );
+        } else if (snapshot.hasError) {
+          return Center(
+            child: Text('Error: ${snapshot.error}'),
+          );
+        } else {
+          return const Center(
+            child: SizedBox(
+              height: 100.0,
+              width: 100.0,
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/lib/spell_search_page.dart
+++ b/lib/spell_search_page.dart
@@ -180,7 +180,6 @@ class _SpellSearchPageState extends State<SpellSearchPage> {
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (context) => SpellPage(
-                          spell: spell,
                           spellId: spellId,
                         ),
                       ),


### PR DESCRIPTION
Makes some slight adjustments to the submitting process so that a spell page is opened immediately after submitting a new spell. Required some changes to spell page to retrieve spell data by id, instead of being passed in data on creation.